### PR TITLE
Fix evaluation's result API format

### DIFF
--- a/src/web/schemas/_util.py
+++ b/src/web/schemas/_util.py
@@ -1,0 +1,2 @@
+def to_kebab(value: str) -> str:
+    return value.replace("_", "-")

--- a/src/web/schemas/poem.py
+++ b/src/web/schemas/poem.py
@@ -2,6 +2,7 @@ from typing import Protocol
 from pydantic import BaseModel
 
 from src.model.poem_evaluation import Evaluation as DomainEvaluation
+from src.web.schemas._util import to_kebab
 
 __all__ = ["Poem"]
 
@@ -12,7 +13,6 @@ class IsPoem(Protocol):
 
     @property
     def evaluation(self) -> DomainEvaluation: ...
-
 
 
 class Evaluation(BaseModel):
@@ -30,15 +30,11 @@ class Evaluation(BaseModel):
             internal_rhyme=model.intern_rhyme_score,
             rhythmic_structure=model.rhyme_structure_score,
             tonic_position=model.stress_score,
-            vocal_harmony=model.consonant_rhyme_score, 
-            score=model.score_result
+            vocal_harmony=model.consonant_rhyme_score,
+            score=model.score_result,
         )
-    
-    class Config:
-        @staticmethod
-        def to_kebab(x: str) -> str:
-            return x.replace("_", "-")
 
+    class Config:
         alias_generator = to_kebab
         populate_by_name = True
 

--- a/src/web/schemas/poem.py
+++ b/src/web/schemas/poem.py
@@ -13,12 +13,6 @@ class IsPoem(Protocol):
     @property
     def evaluation(self) -> DomainEvaluation: ...
 
-
-class EvaluationCounting(BaseModel):
-    evaluations: int
-    rhymes: int
-
-
 class RhymeScore(BaseModel):
     structure: float
     internal: float
@@ -34,7 +28,6 @@ class EvaluationScore(BaseModel):
 
 class Evaluation(BaseModel):
     scores: EvaluationScore
-    countings: EvaluationCounting
 
     @staticmethod
     def from_domain(evaluation: DomainEvaluation) -> "Evaluation":
@@ -49,11 +42,7 @@ class Evaluation(BaseModel):
             ),
         )
 
-        schema_couting = EvaluationCounting(
-            evaluations=evaluation.count, rhymes=evaluation.count_rhyme
-        )
-
-        return Evaluation(scores=schema_score, countings=schema_couting)
+        return Evaluation(scores=schema_score)
 
 
 class Poem(BaseModel):

--- a/src/web/schemas/poem.py
+++ b/src/web/schemas/poem.py
@@ -14,29 +14,25 @@ class IsPoem(Protocol):
     def evaluation(self) -> DomainEvaluation: ...
 
 
-class EvaluationScore(BaseModel):
+
+class Evaluation(BaseModel):
     vocal_harmony: float
     accentuation: float
     tonic_position: float
     internal_rhyme: float
     rhythmic_structure: float
-
-
-class Evaluation(BaseModel):
-    scores: EvaluationScore
     score: float
 
     @staticmethod
     def from_domain(model: DomainEvaluation) -> "Evaluation":
-        schema_score = EvaluationScore(
+        return Evaluation(
             accentuation=model.accent_score,
             internal_rhyme=model.intern_rhyme_score,
             rhythmic_structure=model.rhyme_structure_score,
             tonic_position=model.stress_score,
-            vocal_harmony=model.consonant_rhyme_score
+            vocal_harmony=model.consonant_rhyme_score, 
+            score=model.score_result
         )
-
-        return Evaluation(scores=schema_score, score=model.score_result)
 
 
 class Poem(BaseModel):

--- a/src/web/schemas/poem.py
+++ b/src/web/schemas/poem.py
@@ -33,6 +33,14 @@ class Evaluation(BaseModel):
             vocal_harmony=model.consonant_rhyme_score, 
             score=model.score_result
         )
+    
+    class Config:
+        @staticmethod
+        def to_kebab(x: str) -> str:
+            return x.replace("_", "-")
+
+        alias_generator = to_kebab
+        populate_by_name = True
 
 
 class Poem(BaseModel):

--- a/src/web/schemas/poem.py
+++ b/src/web/schemas/poem.py
@@ -13,36 +13,30 @@ class IsPoem(Protocol):
     @property
     def evaluation(self) -> DomainEvaluation: ...
 
-class RhymeScore(BaseModel):
-    structure: float
-    internal: float
-    consonant: float
-
 
 class EvaluationScore(BaseModel):
-    accent: float
-    stress: float
-    rhymes: RhymeScore
-    result: float
+    vocal_harmony: float
+    accentuation: float
+    tonic_position: float
+    internal_rhyme: float
+    rhythmic_structure: float
 
 
 class Evaluation(BaseModel):
     scores: EvaluationScore
+    score: float
 
     @staticmethod
-    def from_domain(evaluation: DomainEvaluation) -> "Evaluation":
+    def from_domain(model: DomainEvaluation) -> "Evaluation":
         schema_score = EvaluationScore(
-            accent=evaluation.accent_score,
-            stress=evaluation.stress_score,
-            result=evaluation.score_result,
-            rhymes=RhymeScore(
-                structure=evaluation.rhyme_structure_score,
-                internal=evaluation.intern_rhyme_score,
-                consonant=evaluation.consonant_rhyme_score,
-            ),
+            accentuation=model.accent_score,
+            internal_rhyme=model.intern_rhyme_score,
+            rhythmic_structure=model.rhyme_structure_score,
+            tonic_position=model.stress_score,
+            vocal_harmony=model.consonant_rhyme_score
         )
 
-        return Evaluation(scores=schema_score)
+        return Evaluation(scores=schema_score, score=model.score_result)
 
 
 class Poem(BaseModel):

--- a/src/web/schemas/weights.py
+++ b/src/web/schemas/weights.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, Field
 
 from src import api as domain
+from src.web.schemas._util import to_kebab
+
 
 __all__ = ["Weights"]
 
@@ -22,9 +24,5 @@ class Weights(BaseModel):
         )
 
     class Config:
-        @staticmethod
-        def to_kebab(x: str) -> str:
-            return x.replace("_", "-")
-
         alias_generator = to_kebab
         populate_by_name = True


### PR DESCRIPTION
This PR fixes the Evaluation's JSON API format.

I removed the `countings` fields and matched the output of evaluations with the inputs or weights as asked me on the latest reunion.


Example of the output post-PR:

```json
{
  "content": [
    "A retirada foi a salvação",
    "O fato foi de todo inesperado",
    "Requeriam outra reação",
    "Nada referia sobre o passado",
    "",
    "Organiza-se a expedição",
    "Assim, era um desequilibrado",
    "A extrema dor era a extrema-unção",
    "Tinha meio caminho andado",
    "",
    "Dois cartões de visita ao conselheiro",
    "Os jagunços à porta assaltavam-no",
    "Assim todo sertanejo é vaqueiro",
    "",
    "Desafio o mundo inteiro",
    "Assaltam-no; aferram-no; jugulam-no",
    "Subiu o cômoro fronteiro"
  ],
  "evaluation": {
    "vocal-harmony": 7,
    "accentuation": 8,
    "tonic-position": 1.0833333333333335,
    "internal-rhyme": 0.5151515151515152,
    "rhythmic-structure": 4.841666666666667,
    "score": 4.55570707070707
  }
}
```

![image](https://github.com/user-attachments/assets/ba5b7248-d75a-40c9-b929-dcadccf61a91)
