### PR TITLE
Prepare to be run on localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ O [PROPOE](https://linguamatica.com/index.php/linguamatica/article/view/369) *(p
 
 Nessa segunda versão foram implementadas melhorias e adicionados novos critérios rítmicos em comparação com a [primeira versão](https://github.com/lasicuefs/propoe), além da migração do código-fonte de JAVA para Python. Foram implementados ajustes na filtragem de sentenças candidatas, no cálculo dos escores dos versos, alteração do parâmetro de metro para que o usuário possa definir metros diferentes para cada verso, adição dos critérios de rima interna, consoante e toante, inclusão dos parâmetros de esquema rítmico e peso dos critérios. Este último permite que o usuário defina quais critérios devem ser mais importantes no momento da montagem do poema.
 
+## Execução
+
+Instalando dependências do Poetry:
+
+```sh
+poetry install
+```
+
+Inicializando o ambiente:
+
+```sh
+poetry shell
+```
+
+Executando o servidor
+
+```sh
+fastapi dev src/web
+```
+
 ## Código
 
 Para roda o código basta executar o arquivo *propoe2/run.py*

--- a/src/model/filter.py
+++ b/src/model/filter.py
@@ -50,6 +50,8 @@ class Filter:
         return sentences
 
     def random_rhyme(self, rhymes):
+        # TODO: review this function
+        # Try: A10 B5 A10 B5 Prosody
         """Return a random Rhyme object inside a list of Rhyme objects"""
         number = random.randrange(len(rhymes))
         rhyme = rhymes[number]

--- a/src/web/__init__.py
+++ b/src/web/__init__.py
@@ -1,27 +1,45 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 
 from src import api as propoe
-from src.web import schemas
+from src.web.schemas.prosody import Prosody
+from src.web.schemas.weights import Weights
+from src.web.schemas.poem import Poem
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "http://localhost:4200",
+        "https://localhost:4200",
+        "http://127.0.0.1:4200",
+        "https://127.0.0.1:4200",
+        "http://rickbarretto.github.io/propoe2-ui/",
+        "https://rickbarretto.github.io/propoe2-ui/",
+    ],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
+class Entry(BaseModel):
+    prosody: Prosody
+    weights: Weights
 
 @app.post("/poem/")
-async def poem(
-    prosody: schemas.Prosody, weights: schemas.Weights = schemas.Weights()
-) -> schemas.Poem:
+async def poem(entry: Entry) -> Poem:
     result = propoe.Propoe(
         filename="poem_test_api.txt",
         mives_file="xml/sentencas.xml",
-        prosody=prosody.as_domain(),
-        evaluation_weights=weights.as_domain(),
+        prosody=entry.prosody.as_domain(),
+        evaluation_weights=entry.weights.as_domain(),
     ).poem
 
-    return schemas.Poem.from_domain(result)
-
+    return Poem.from_domain(result)
 
 @app.get("/sample/")
-async def sample() -> schemas.Poem:
+async def sample() -> Poem:
     prosody = propoe.Prosody(
         "ABAB ABAB CDC CDC",
         [10] * 14,
@@ -36,4 +54,4 @@ async def sample() -> schemas.Poem:
         evaluation_weights=weights,
     ).poem
 
-    return schemas.Poem.from_domain(result)
+    return Poem.from_domain(result)


### PR DESCRIPTION
This PR allows Propoe to run on localhost being able to serve the API for the Frontend.

This:
* Solve CORS issues, allowing it to be get requests from the port `4200`
* Add a simple execution instructions on README